### PR TITLE
Better handling for trailing slashes. (#2154)

### DIFF
--- a/integrations/actix/tests/extract_routes.rs
+++ b/integrations/actix/tests/extract_routes.rs
@@ -1,0 +1,53 @@
+use leptos::*;
+use leptos_router::{Router, Routes, Route};
+use leptos_actix::generate_route_list;
+
+#[component]
+fn ExampleApp() -> impl IntoView {
+    let view = || view! { "" };
+    view! {
+        <Router>
+            <Routes>
+                <Route path="/foo" view/>
+                <Route path="/bar/" view/>
+                <Route path="/baz/:id" view/>
+                <Route path="/baz/:name/" view/>
+                <Route path="/baz/*any" view/>
+            </Routes>
+        </Router>
+    }
+}
+
+#[test]
+fn test_extracting_routes() {
+    let routes = generate_route_list(ExampleApp);
+
+    // We still have access to the original Leptos paths:
+    let mut leptos_paths: Vec<_> = routes
+        .iter()
+        .map(|route| route.leptos_path())
+        .collect();
+    leptos_paths.sort();
+    assert_eq!(leptos_paths, [
+        "/bar/",
+        "/baz/*any",
+        "/baz/:id",
+        "/baz/:name/",
+        "/foo",
+    ]);
+
+    // ... But leptos-actix has also reformatted "paths" to work for Actix.
+    let mut paths: Vec<_> = routes
+        .iter()
+        .map(|route| route.path())
+        .collect();
+    paths.sort();
+    assert_eq!(paths, [
+        "/bar/",
+        "/baz/{id}",
+        "/baz/{name}/",
+        "/baz/{tail:.*}",
+        "/foo",
+    ]);
+}
+

--- a/router/src/components/route.rs
+++ b/router/src/components/route.rs
@@ -1,6 +1,6 @@
 use crate::{
     matching::{resolve_path, PathMatch, RouteDefinition, RouteMatch},
-    ParamsMap, RouterContext, SsrMode, StaticData, StaticMode, StaticParamsMap,
+    ParamsMap, RouterContext, SsrMode, StaticData, StaticMode, StaticParamsMap, TrailingSlash,
 };
 use leptos::{leptos_dom::Transparent, *};
 use std::{
@@ -15,6 +15,16 @@ use std::{
 
 thread_local! {
     static ROUTE_ID: Cell<usize> = Cell::new(0);
+}
+
+// RouteDefinition.id is `pub` and required to be unique.
+// Should we make this public so users can generate unique IDs?
+pub(in crate::components) fn new_route_id() -> usize {
+    ROUTE_ID.with(|id| {
+        let next = id.get() + 1;
+        id.set(next);
+        next
+    })
 }
 
 /// Represents an HTTP method that can be handled by this route.
@@ -65,6 +75,11 @@ pub fn Route<E, F, P>(
     /// accessed with [`use_route_data`](crate::use_route_data).
     #[prop(optional, into)]
     data: Option<Loader>,
+    /// How this route should handle trailing slashes in its path.
+    /// Overrides any setting applied to [`crate::components::Router`].
+    /// Serves as a default for any inner Routes.
+    #[prop(optional)]
+    trailing_slash: Option<TrailingSlash>,
     /// `children` may be empty or include nested routes.
     #[prop(optional)]
     children: Option<Children>,
@@ -83,8 +98,10 @@ where
         data,
         None,
         None,
+        trailing_slash,
     )
 }
+
 
 /// Describes a route that is guarded by a certain condition. This works the same way as
 /// [`<Route/>`](Route), except that if the `condition` function evaluates to `false`, it
@@ -115,6 +132,11 @@ pub fn ProtectedRoute<P, E, F, C>(
     /// accessed with [`use_route_data`](crate::use_route_data).
     #[prop(optional, into)]
     data: Option<Loader>,
+    /// How this route should handle trailing slashes in its path.
+    /// Overrides any setting applied to [`crate::components::Router`].
+    /// Serves as a default for any inner Routes.
+    #[prop(optional)]
+    trailing_slash: Option<TrailingSlash>,
     /// `children` may be empty or include nested routes.
     #[prop(optional)]
     children: Option<Children>,
@@ -143,6 +165,7 @@ where
         data,
         None,
         None,
+        trailing_slash,
     )
 }
 
@@ -171,6 +194,11 @@ pub fn StaticRoute<E, F, P, S>(
     /// accessed with [`use_route_data`](crate::use_route_data).
     #[prop(optional, into)]
     data: Option<Loader>,
+    /// How this route should handle trailing slashes in its path.
+    /// Overrides any setting applied to [`crate::components::Router`].
+    /// Serves as a default for any inner Routes.
+    #[prop(optional)]
+    trailing_slash: Option<TrailingSlash>,
     /// `children` may be empty or include nested routes.
     #[prop(optional)]
     children: Option<Children>,
@@ -193,6 +221,7 @@ where
         data,
         Some(mode),
         Some(Arc::new(static_params)),
+        trailing_slash,
     )
 }
 
@@ -210,6 +239,7 @@ pub(crate) fn define_route(
     data: Option<Loader>,
     static_mode: Option<StaticMode>,
     static_params: Option<StaticData>,
+    trailing_slash: Option<TrailingSlash>,
 ) -> RouteDefinition {
     let children = children
         .map(|children| {
@@ -226,14 +256,8 @@ pub(crate) fn define_route(
         })
         .unwrap_or_default();
 
-    let id = ROUTE_ID.with(|id| {
-        let next = id.get() + 1;
-        id.set(next);
-        next
-    });
-
     RouteDefinition {
-        id,
+        id: new_route_id(),
         path,
         children,
         view,
@@ -242,6 +266,7 @@ pub(crate) fn define_route(
         data,
         static_mode,
         static_params,
+        trailing_slash,
     }
 }
 

--- a/router/src/components/router.rs
+++ b/router/src/components/router.rs
@@ -26,13 +26,16 @@ pub fn Router(
     /// A signal that will be set while the navigation process is underway.
     #[prop(optional, into)]
     set_is_routing: Option<SignalSetter<bool>>,
+    /// How trailing slashes should be handled in [`Route`] paths.
+    #[prop(optional)]
+    trailing_slash: Option<TrailingSlash>,
     /// The `<Router/>` should usually wrap your whole page. It can contain
     /// any elements, and should include a [`Routes`](crate::Routes) component somewhere
     /// to define and display [`Route`](crate::Route)s.
     children: Children,
 ) -> impl IntoView {
     // create a new RouterContext and provide it to every component beneath the router
-    let router = RouterContext::new(base, fallback);
+    let router = RouterContext::new(base, fallback, trailing_slash);
     provide_context(router);
     provide_context(GlobalSuspenseContext::new());
     if let Some(set_is_routing) = set_is_routing {
@@ -53,6 +56,7 @@ pub struct RouterContext {
 pub(crate) struct RouterContextInner {
     pub location: Location,
     pub base: RouteContext,
+    trailing_slash: Option<TrailingSlash>,
     pub possible_routes: RefCell<Option<Vec<Branch>>>,
     #[allow(unused)] // used in CSR/hydrate
     base_path: String,
@@ -89,6 +93,7 @@ impl RouterContext {
     pub(crate) fn new(
         base: Option<&'static str>,
         fallback: Option<fn() -> View>,
+        trailing_slash: Option<TrailingSlash>,
     ) -> Self {
         cfg_if! {
             if #[cfg(any(feature = "csr", feature = "hydrate"))] {
@@ -169,6 +174,7 @@ impl RouterContext {
             path_stack: store_value(vec![location.pathname.get_untracked()]),
             location,
             base,
+            trailing_slash,
             history: Box::new(history),
 
             reference,
@@ -201,6 +207,10 @@ impl RouterContext {
     /// The [`RouteContext`] of the base route.
     pub fn base(&self) -> RouteContext {
         self.inner.base.clone()
+    }
+
+    pub(crate) fn trailing_slash(&self) -> Option<TrailingSlash> {
+        self.inner.trailing_slash.clone()
     }
 
     /// A list of all possible routes this router can match.
@@ -457,6 +467,74 @@ impl Default for NavigateOptions {
             replace: false,
             scroll: true,
             state: State(None),
+        }
+    }
+}
+
+/// Declares how you would like to handle trailing slashes in Route paths. This
+/// can be set on [`Router`] and overridden in [`crate::components::Route`]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum TrailingSlash {
+    /// This is the default behavior as of Leptos 0.5.  Trailing slashes in your
+    /// `Route` path are stripped. i.e.: the following two route declarations
+    /// are equivalent:
+    ///  * `<Route path="/foo">`
+    ///  * `<Route path="/foo/">`
+    Drop,
+
+    /// This mode will respect your path as it is written. Ex:
+    ///  * If you specify `<Route path="/foo">`, then `/foo` matches, but
+    ///    `/foo/` does not.
+    ///  * If you specify `<Route path="/foo/">`, then `/foo/` matches, but
+    ///    `/foo` does not.
+    Exact,
+
+    /// Like `Exact`, this mode respects your path as-written. But it will also
+    /// add redirects to the specified path if a user nagivates to a URL that is
+    /// off by only the trailing slash.
+    /// 
+    /// Given `<Route path="/foo">`
+    ///  * Visiting `/foo` is valid.
+    ///  * Visiting `/foo/` serves a redirect to `/foo` 
+    /// 
+    /// Given `<Route path="/foo/">`
+    ///  * Visiting `/foo` serves a redirect to `/foo/` 
+    ///  * Visiting `/foo/` is valid.
+    Redirect,
+}
+
+impl Default for TrailingSlash {
+    fn default() -> Self {
+        // This is the behavior in 0.5. Keeping it the default for backward compatibility. 
+        // TODO: Change to `Redirect` in 0.6?
+        Self::Drop 
+    }
+}
+
+impl TrailingSlash {    
+    /// Should we redirect requests that come in with the wrong (extra/missing) trailng slash?
+    pub(crate) fn should_redirect(&self) -> bool {
+        use TrailingSlash::*;
+        match self {
+            Redirect => true,
+            Drop | Exact => false,
+        }
+    }
+
+    pub(crate) fn normalize_route_path(&self, path: &mut String) {
+        if !self.should_drop() {
+            return;
+        }
+        while path.ends_with("/") {
+            path.pop();
+        }
+    }
+
+    fn should_drop(&self) -> bool {
+        use TrailingSlash::*;
+        match self {
+            Redirect | Exact => false,
+            Drop => true,
         }
     }
 }

--- a/router/src/components/routes.rs
+++ b/router/src/components/routes.rs
@@ -638,7 +638,6 @@ fn create_routes(
     for original_path in expand_optionals(&route_def.path) {
         // compat: trim_end_matches ensures that routes with trailing slash still match ones with no trailing slash
         let path = join_paths(base, &original_path)
-            .trim_end_matches('/')
             .to_string();
         let pattern = if is_leaf {
             path

--- a/router/src/extract_routes.rs
+++ b/router/src/extract_routes.rs
@@ -11,7 +11,7 @@ use std::{
 
 /// Context to contain all possible routes.
 #[derive(Clone, Default, Debug)]
-pub struct PossibleBranchContext(pub(crate) Rc<RefCell<Vec<Branch>>>);
+pub struct PossibleBranchContext(pub Rc<RefCell<Vec<Branch>>>);
 
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 /// A route that this application can serve.

--- a/router/src/extract_routes.rs
+++ b/router/src/extract_routes.rs
@@ -42,6 +42,9 @@ impl RouteListing {
     }
 
     /// The path this route handles.
+    /// 
+    /// This should be formatted for whichever web server integegration is being used. (ex: leptos-actix.)
+    /// When returned from leptos-router, it matches `self.leptos_path()`.  
     pub fn path(&self) -> &str {
         &self.path
     }

--- a/router/src/matching/route.rs
+++ b/router/src/matching/route.rs
@@ -1,4 +1,4 @@
-use crate::{Loader, Method, SsrMode, StaticData, StaticMode};
+use crate::{Loader, Method, SsrMode, StaticData, StaticMode, TrailingSlash};
 use leptos::leptos_dom::View;
 use std::rc::Rc;
 
@@ -25,6 +25,8 @@ pub struct RouteDefinition {
     pub static_mode: Option<StaticMode>,
     /// The data required to fill any dynamic segments in the path during static rendering.
     pub static_params: Option<StaticData>,
+    /// How a trailng slash in `path` should be handled.
+    pub trailing_slash: Option<TrailingSlash>,
 }
 
 impl core::fmt::Debug for RouteDefinition {
@@ -34,6 +36,7 @@ impl core::fmt::Debug for RouteDefinition {
             .field("children", &self.children)
             .field("ssr_mode", &self.ssr_mode)
             .field("static_render", &self.static_mode)
+            .field("trailing_slash", &self.trailing_slash)
             .finish()
     }
 }

--- a/router/tests/extract_routes.rs
+++ b/router/tests/extract_routes.rs
@@ -1,0 +1,56 @@
+#![cfg(feature = "ssr")]
+
+use itertools::Itertools;
+use leptos::*;
+use leptos_router::{Router, Routes, Route};
+
+#[component]
+fn ExampleApp() -> impl IntoView {
+    let view = || view! { "" };
+    view! {
+        <Router>
+            <Routes>
+                <Route path="/foo" view/>
+                <Route path="/bar/" view/>
+                <Route path="/baz/:id" view/>
+                <Route path="/baz/:name/" view/>
+                <Route path="/baz/*any" view/>
+            </Routes>
+        </Router>
+    }
+}
+
+/// These routes are extracted and used by the actix/axum/viz integrations.
+/// Make sure we're returning accurate paths to them. (w/ trailing slash).
+#[test]
+fn test_extracting_routes() {
+    let (routes, hashmap) = leptos_router::generate_route_list_inner(ExampleApp);
+    dbg!(hashmap.keys());
+
+    let mut paths = routes
+        .iter()
+        .map(|route| route.path())
+        .collect_vec();
+    paths.sort();
+    assert_eq!(paths, [
+        "/bar/",
+        "/baz/*any",
+        "/baz/:id",
+        "/baz/:name/",
+        "/foo",
+    ]);
+
+    // integrations can update "path" to be valid for themselves, but
+    // when routes are returned by leptos_router, these are equals:
+    assert!(
+        routes
+            .iter()
+            .all(|route| route.path() == route.leptos_path())
+    );
+
+    let mut keys = hashmap.keys().collect_vec();
+    keys.sort();
+    assert_eq!(paths, keys);
+
+}
+

--- a/router/tests/extract_routes.rs
+++ b/router/tests/extract_routes.rs
@@ -2,10 +2,10 @@
 
 use itertools::Itertools;
 use leptos::*;
-use leptos_router::{Router, Routes, Route};
+use leptos_router::{Router, Routes, Route, TrailingSlash, generate_route_list_inner, Branch};
 
 #[component]
-fn ExampleApp() -> impl IntoView {
+fn DefaultApp() -> impl IntoView {
     let view = || view! { "" };
     view! {
         <Router>
@@ -20,37 +20,157 @@ fn ExampleApp() -> impl IntoView {
     }
 }
 
-/// These routes are extracted and used by the actix/axum/viz integrations.
-/// Make sure we're returning accurate paths to them. (w/ trailing slash).
+#[component]
+fn ExactApp() -> impl IntoView {
+    let view = || view! { "" };
+    let trailing_slash = TrailingSlash::Exact;
+    view! {
+        <Router trailing_slash>
+            <Routes>
+                <Route path="/foo" view/>
+                <Route path="/bar/" view/>
+                <Route path="/baz/:id" view/>
+                <Route path="/baz/:name/" view/>
+                <Route path="/baz/*any" view/>
+            </Routes>
+        </Router>
+    }
+}
+
+#[component]
+fn RedirectApp() -> impl IntoView {
+    let view = || view! { "" };
+    let trailing_slash = TrailingSlash::Redirect;
+    view! {
+        <Router trailing_slash>
+            <Routes>
+                <Route path="/foo" view/>
+                <Route path="/bar/" view/>
+                <Route path="/baz/:id" view/>
+                <Route path="/baz/:name/" view/>
+                <Route path="/baz/*any" view/>
+            </Routes>
+        </Router>
+    }
+}
 #[test]
-fn test_extracting_routes() {
-    let (routes, hashmap) = leptos_router::generate_route_list_inner(ExampleApp);
-    dbg!(hashmap.keys());
+fn test_generated_routes_default() {
+    // By default, we use the behavior as of Leptos 0.5, which is equivalent to TrailingSlash::Drop.
+    assert_generated_paths(DefaultApp, &[
+        "/bar",
+        "/baz/*any",
+        "/baz/:id",
+        "/baz/:name",
+        "/foo", 
+    ]);
+}
+
+#[test]
+fn test_generated_routes_exact() {
+    // Allow users to precisely define whether slashes are present:
+    assert_generated_paths(ExactApp, &[
+        "/bar/",
+        "/baz/*any",
+        "/baz/:id",
+        "/baz/:name/",
+        "/foo", 
+    ]);
+}
+
+#[test]
+fn test_generated_routes_redirect() {
+    // TralingSlashes::Redirect generates paths to redirect to the path with the "correct" trailing slash ending (or lack thereof).
+    assert_generated_paths(RedirectApp, &[
+        "/bar",
+        "/bar/",
+        "/baz/*any",
+        "/baz/*any/", // !!! TODO
+        "/baz/:id",
+        "/baz/:id/",
+        "/baz/:name",
+        "/baz/:name/",
+        "/foo",     
+        "/foo/",     
+    ])
+
+    // TODO:
+    // Test we get a redirect from "/foo/" to "/foo"
+    // Test we get a redirect from "/bar" to "/bar/".
+}
+
+// WARNING!
+// 
+// Despite generate_route_list_inner() using a new leptos_reactive::RuntimeID
+// each time we call this function, somehow Routes are leaked between different
+// apps. To avoid that, make sure to put each call in a separate #[test] method.
+//
+// TODO: Better isolation for different apps to avoid this issue?
+fn assert_generated_paths<F, IV>(app: F, expected_sorted_paths: &[&str])
+where
+    F:  Clone + Fn() -> IV + 'static,
+    IV: IntoView + 'static
+{
+    let (routes, static_data) = generate_route_list_inner(app);
 
     let mut paths = routes
         .iter()
         .map(|route| route.path())
         .collect_vec();
     paths.sort();
-    assert_eq!(paths, [
-        "/bar/",
-        "/baz/*any",
-        "/baz/:id",
-        "/baz/:name/",
-        "/foo",
-    ]);
+
+    assert_eq!(paths, expected_sorted_paths);
+
+    let mut keys = static_data.keys().collect_vec();
+    keys.sort();
+    assert_eq!(paths, keys);
 
     // integrations can update "path" to be valid for themselves, but
-    // when routes are returned by leptos_router, these are equals:
+    // when routes are returned by leptos_router, these are equal:
     assert!(
         routes
             .iter()
             .all(|route| route.path() == route.leptos_path())
     );
+}
 
-    let mut keys = hashmap.keys().collect_vec();
-    keys.sort();
-    assert_eq!(paths, keys);
+#[test]
+fn test_unique_route_ids() {
+    let branches = get_branches(RedirectApp);
+    assert!(!branches.is_empty());
+
+    assert!(
+        branches.iter()
+            .flat_map(|branch| &branch.routes)
+            .map(|route| route.id)
+            .all_unique()
+    );
 
 }
 
+/// This is how [`generate_route_list_inner`] gets its RouteDefinitions.
+/// But it doesn't expose it anywhere where we can easily test it, so here's a quick copy:
+fn get_branches<F, IV>(app_fn: F) -> Vec<Branch>
+where
+    F: Fn() -> IV + Clone + 'static,
+    IV: IntoView,
+{
+    use leptos_router::*;
+
+    let runtime = create_runtime();
+
+    let integration = ServerIntegration {
+        path: "http://leptos.rs/".to_string(),
+    };
+
+    provide_context(RouterIntegrationContext::new(integration));
+    let branches = PossibleBranchContext::default();
+    provide_context(branches.clone());
+
+    leptos::suppress_resource_load(true);
+    _ = app_fn().into_view();
+    leptos::suppress_resource_load(false);
+
+    let branches = branches.0.borrow().clone();
+    runtime.dispose();
+    branches
+}

--- a/router/tests/trailing_slashes.rs
+++ b/router/tests/trailing_slashes.rs
@@ -1,0 +1,35 @@
+//! Some extra tests for Matcher NOT based on SolidJS's tests cases (as in matcher.rs)
+
+use leptos_router::{Matcher, params_map};
+
+#[test] 
+fn trailing_slashes_match_exactly() {
+    let matcher = Matcher::new("/foo/");
+    assert!(matches(&matcher, "/foo/"));
+    assert!(!matches(&matcher, "/foo"));
+
+    let matcher = Matcher::new("/foo/bar/");
+    assert!(matches(&matcher, "/foo/bar/"));
+    assert!(!matches(&matcher, "/foo/bar"));
+    assert!(!matches(&matcher, "/foo/"));
+    assert!(!matches(&matcher, "/foo"));
+}
+
+#[test]
+fn trailng_slashes_params_match_exactly() {
+    let matcher = Matcher::new("/foo/:bar/");
+    assert!(matches(&matcher, "/foo/bar/"));
+    assert!(matches(&matcher, "/foo/42/"));
+    assert!(matches(&matcher, "/foo/%20/"));
+
+    assert!(!matches(&matcher, "/foo/bar"));
+    assert!(!matches(&matcher, "/foo/42"));
+    assert!(!matches(&matcher, "/foo/%20"));
+
+    let m = matcher.test("/foo/asdf/").unwrap();
+    assert_eq!(m.params, params_map!{ "bar" => "asdf" });
+}
+
+fn matches(m: &Matcher, loc: &str) -> bool {
+    m.test(loc).is_some()
+}


### PR DESCRIPTION

This adds a trailing_slash option to `<Router>` and `<Route>`.

By default, this option is backward compatible with current Leptos
behavior, but users can opt into two new modes for handling trailing
slashes.